### PR TITLE
fix: initialize file size

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,6 +84,15 @@ function buildFileName (fileVal, lastNumber = 1, extension) {
   return `${getFileName(fileVal)}.${lastNumber}${extension ?? ''}`
 }
 
+async function getFileSize (filePath) {
+  try {
+    const fileStats = await stat(filePath)
+    return fileStats.size
+  } catch {
+    return 0
+  }
+}
+
 async function detectLastNumber (fileVal, time = null) {
   const fileName = getFileName(fileVal)
   try {
@@ -134,5 +143,6 @@ module.exports = {
   getNext,
   parseSize,
   getFileName,
+  getFileSize,
   validateLimitOptions
 }

--- a/pino-roll.js
+++ b/pino-roll.js
@@ -8,6 +8,7 @@ const {
   parseSize,
   parseFrequency,
   getNext,
+  getFileSize,
   validateLimitOptions
 } = require('./lib/utils')
 
@@ -76,7 +77,7 @@ module.exports = async function ({
 
   const fileName = buildFileName(file, number, extension)
   const createdFileNames = [fileName]
-  let currentSize = 0
+  let currentSize = await getFileSize(fileName)
   const maxSize = parseSize(size)
 
   const destination = new SonicBoom({ ...opts, dest: fileName })
@@ -94,7 +95,7 @@ module.exports = async function ({
       currentSize += writtenSize
       if (currentSize >= maxSize) {
         currentSize = 0
-        // delay to let the our destination finish its write
+        // delay to let the destination finish its write
         setTimeout(roll, 0)
       }
     })

--- a/test/lib/utils.test.js
+++ b/test/lib/utils.test.js
@@ -7,6 +7,7 @@ const { test } = require('tap')
 
 const {
   buildFileName,
+  getFileSize,
   detectLastNumber,
   getNext,
   parseFrequency,
@@ -53,7 +54,7 @@ test('parseFrequency()', async ({ same, throws }) => {
   throws(() => parseFrequency('null'), 'throws on non parseable string')
 })
 
-test('getNext()', async ({ same, throws }) => {
+test('getNext()', async ({ same }) => {
   const today = new Date()
 
   same(getNext('daily'), startOfDay(addDays(today, 1)).getTime(), 'supports daily frequency')
@@ -75,6 +76,23 @@ test('buildFileName()', async ({ equal, throws }) => {
   equal(buildFileName('my-file'), 'my-file.1', 'appends 1 by default')
   equal(buildFileName(() => 'my-func'), 'my-func.1', 'appends 1 by default')
   equal(buildFileName('my-file', 5, ext), 'my-file.5.json', 'appends number and extension')
+})
+
+test('getFileSize()', async ({ test, beforeEach }) => {
+  const folder = join('logs', 'utils')
+  beforeEach(() => cleanAndCreateFolder(folder))
+
+  test('given an existing file', async ({ equal }) => {
+    const fileName = join(folder, 'file.log')
+    await writeFile(fileName, '123')
+
+    equal(await getFileSize(fileName), 3, 'detects size of existing file')
+  })
+
+  test('given a non existing file', async ({ equal }) => {
+    const fileName = join(folder, 'file.log')
+    equal(await getFileSize(fileName), 0, 'set current size to 0 with non existing file')
+  })
 })
 
 test('detectLastNumber()', async ({ test, beforeEach }) => {

--- a/test/pino-roll.test.js
+++ b/test/pino-roll.test.js
@@ -123,7 +123,7 @@ test('do not remove pre-existing file when removing files based on count', async
     file,
     limit: { count: 2 }
   })
-  for (let i = 1; i <= 7; i++) {
+  for (let i = 1; i <= 6; i++) {
     stream.write(`logged message #${i}\n`)
     await sleep(20)
   }
@@ -134,14 +134,13 @@ test('do not remove pre-existing file when removing files based on count', async
   await stat(`${file}.3`)
   content = await readFile(`${file}.3`, 'utf8')
   ok(content.includes('#3'), 'second file contains third log')
-  ok(content.includes('#4'), 'second file contains fourth log')
   await stat(`${file}.4`)
   content = await readFile(`${file}.4`, 'utf8')
+  ok(content.includes('#4'), 'third file contains fourth log')
   ok(content.includes('#5'), 'third file contains fifth log')
-  ok(content.includes('#6'), 'third file contains sixth log')
   await stat(`${file}.5`)
   content = await readFile(`${file}.5`, 'utf8')
-  ok(content.includes('#7'), 'fourth file contains seventh log')
+  ok(content.includes('#6'), 'fourth file contains sixth log')
   await rejects(stat(`${file}.2`), 'resumed file was deleted')
   await rejects(stat(`${file}.6`), 'no other files created')
 })


### PR DESCRIPTION
The currentSize was initialised to zero, causing the rolling to not happen on restarting the transport.

Fix #34 