### PR TITLE
fix: Fix daily frequency compensating for DST

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const { readdir, stat, unlink, symlink, lstat, readlink } = require('fs/promises')
 const { dirname, join } = require('path')
-const { format } = require('date-fns')
+const { format, addDays, addHours } = require('date-fns')
 
 function parseSize (size) {
   let multiplier = 1024 ** 2
@@ -53,11 +53,11 @@ function validateLimitOptions (limit) {
 }
 
 function getNextDay (start) {
-  return new Date(start + 24 * 60 * 60 * 1000).setHours(0, 0, 0, 0)
+  return addDays(new Date(start), 1).setHours(0, 0, 0, 0)
 }
 
 function getNextHour (start) {
-  return new Date(start + 60 * 60 * 1000).setMinutes(0, 0, 0)
+  return addHours(new Date(start), 1).setMinutes(0, 0, 0)
 }
 
 function getNextCustom (frequency) {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "husky": "^9.0.11",
+    "mockdate": "^3.0.5",
     "pino": "^9.2.0",
     "snazzy": "^9.0.0",
     "standard": "^17.0.0-2",


### PR DESCRIPTION
The date transitioning from Standard Time to DST "has" 25 hours in the day. This fixes genNextDay to use `date-fns` so the correct day is returned instead of naively adding 24 hours to the date.

It additionally replaces the date generation in `genNextHour` so it also uses `date-fns` so that any DST/timezone quirks are accounted for by date-fns.

Fixes #95