### PR TITLE
Add option limit.removeOtherLogFiles extending count-based removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,15 +65,16 @@ You can specify any of [Sonic-Boom options](https://github.com/pinojs/sonic-boom
 
 * `limit.count?`: number of log files, **in addition to the currently used file**.
 
+* `limit.removeOtherLogFiles?`: boolean:  
+When true, will remove files not created by the current process. 
+When false/undefined, count limiattion will only apply to files created by the current process. 
+
 * `dateFormat?`: the format for appending the current date/time to the file name.
   When specified, appends the date/time in the provided format to the log file name.
   Supports date formats from `date-fns` (see: [date-fns format documentation](https://date-fns.org/v4.1.0/docs/format)).
   For example:
     Daily: `'yyyy-MM-dd'` → `error.2024-09-24.log`
     Hourly: `'yyyy-MM-dd-hh'` → `error.2024-09-24-05.log`
-
-Please not that `limit` only considers **created log files**. It will not consider any pre-existing files.
-Therefore, starting your logger with a limit will never tries deleting older log files, created during previous executions.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can specify any of [Sonic-Boom options](https://github.com/pinojs/sonic-boom
 
 * `limit.removeOtherLogFiles?`: boolean:  
 When true, will remove files not created by the current process. 
-When false/undefined, count limiattion will only apply to files created by the current process. 
+When false/undefined, count limitation will only apply to files created by the current process. 
 
 * `dateFormat?`: the format for appending the current date/time to the file name.
   When specified, appends the date/time in the provided format to the log file name.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,7 +2,7 @@
 
 const { readdir, stat, unlink, symlink, lstat, readlink } = require('fs/promises')
 const { dirname, join } = require('path')
-const { format, addDays, addHours } = require('date-fns')
+const { format, addDays, addHours, parse, isValid } = require('date-fns')
 
 function parseSize (size) {
   let multiplier = 1024 ** 2
@@ -50,6 +50,9 @@ function validateLimitOptions (limit) {
     if (typeof limit.count !== 'number' || limit.count <= 0) {
       throw new Error('limit.count must be a number greater than 0')
     }
+    if (typeof limit.removeOtherLogFiles !== 'undefined' && typeof limit.removeOtherLogFiles !== 'boolean') {
+      throw new Error('limit.removeOtherLogFiles must be boolean')
+    }
   }
 }
 
@@ -85,7 +88,37 @@ function getFileName (fileVal) {
 
 function buildFileName (fileVal, date, lastNumber = 1, extension) {
   const dateStr = date ? `.${date}` : ''
-  return `${getFileName(fileVal)}${dateStr}.${lastNumber}${extension ?? ''}`
+  const extensionStr = typeof extension !== 'string' ? '' : extension.startsWith('.') ? extension : `.${extension}`
+  return `${getFileName(fileVal)}${dateStr}.${lastNumber}${extensionStr}`
+}
+
+function identifyLogFile (checkedFileName, fileVal, dateFormat, extension) {
+  const baseFileNameStr = getFileName(fileVal)
+  if (!checkedFileName.startsWith(baseFileNameStr)) return false
+  const checkFileNameSegments = checkedFileName
+    .slice(baseFileNameStr.length + 1)
+    .split('.')
+  let expectedSegmentCount = 1
+  if (typeof dateFormat === 'string' && dateFormat.length > 0) expectedSegmentCount++
+  if (typeof extension === 'string' && extension.length > 0) expectedSegmentCount++
+  const extensionStr = typeof extension !== 'string' ? '' : extension.startsWith('.') ? extension.slice(1) : extension
+  if (checkFileNameSegments.length !== expectedSegmentCount) return false
+  if (extensionStr.length > 0) {
+    const chkExtension = checkFileNameSegments.pop()
+    if (extensionStr !== chkExtension) return false
+  }
+  const chkFileNumber = checkFileNameSegments.pop()
+  const fileNumber = Number(chkFileNumber)
+  if (!Number.isInteger(fileNumber)) {
+    return false
+  }
+  let fileTime = 0
+  if (typeof dateFormat === 'string' && dateFormat.length > 0) {
+    const d = parse(checkFileNameSegments[0], dateFormat, new Date())
+    if (!isValid(d)) return false
+    fileTime = d.getTime()
+  }
+  return { fileName: checkedFileName, fileTime, fileNumber }
 }
 
 async function getFileSize (filePath) {
@@ -135,12 +168,37 @@ async function isMatchingTime (filePath, time) {
   return birthtimeMs >= time
 }
 
-async function checkFileRemoval (files, { count }) {
-  if (files.length > count) {
-    const filesToRemove = files.splice(0, files.length - 1 - count)
-    await Promise.allSettled(filesToRemove.map(file => unlink(file)))
+async function removeOldFiles ({ count, removeOtherLogFiles, baseFile, dateFormat, extension, createdFileNames, newFileName }) {
+  if (!removeOtherLogFiles) {
+    createdFileNames.push(newFileName)
+    if (createdFileNames.length > count) {
+      const filesToRemove = createdFileNames.splice(0, createdFileNames.length - 1 - count)
+      await Promise.allSettled(filesToRemove.map(file => unlink(file)))
+    }
+  } else {
+    let files = []
+    const pathSegments = getFileName(baseFile).split(/(\\|\/)/g)
+    const baseFileNameStr = pathSegments.pop()
+    for (const fileEntry of await readdir(join(...pathSegments))) {
+      const f = identifyLogFile(fileEntry, baseFileNameStr, dateFormat, extension)
+      if (f) {
+        files.push(f)
+      }
+    }
+    files = files.sort((i, j) => {
+      if (i.fileTime === j.fileTime) {
+        return i.fileNumber - j.fileNumber
+      }
+      return i.fileTime - j.fileTime
+    })
+    if (files.length > count) {
+      await Promise.allSettled(
+        files
+          .slice(0, files.length - count)
+          .map(file => unlink(join(...pathSegments, file.fileName)))
+      )
+    }
   }
-  return files
 }
 
 async function checkSymlink (fileName, linkPath) {
@@ -184,7 +242,8 @@ function parseDate (formatStr, frequencySpec, parseStart = false) {
 
 module.exports = {
   buildFileName,
-  checkFileRemoval,
+  identifyLogFile,
+  removeOldFiles,
   checkSymlink,
   createSymlink,
   detectLastNumber,

--- a/pino-roll.js
+++ b/pino-roll.js
@@ -132,7 +132,9 @@ module.exports = async function ({
   function scheduleRoll () {
     clearTimeout(rollTimeout)
     rollTimeout = setTimeout(() => {
+      const prevDate = date
       date = parseDate(dateFormat, frequencySpec)
+      if (dateFormat && date && date !== prevDate) number = 0
       fileName = buildFileName(file, date, ++number, extension)
       roll()
       frequencySpec.next = getNext(frequency)

--- a/pino-roll.js
+++ b/pino-roll.js
@@ -3,7 +3,7 @@
 const SonicBoom = require('sonic-boom')
 const {
   buildFileName,
-  checkFileRemoval,
+  removeOldFiles,
   createSymlink,
   detectLastNumber,
   parseSize,
@@ -57,6 +57,7 @@ const {
  * @typedef {object} LimitOptions
  *
  * @property {number} count? -number of log files, **in addition to the currently used file**.
+ * @property {boolean} removeOtherLogFiles? - when true, older file matching the log file format will also be removed.
  */
 
 /**
@@ -85,7 +86,7 @@ module.exports = async function ({
   const frequencySpec = parseFrequency(frequency)
 
   let date = parseDate(dateFormat, frequencySpec, true)
-  let number = await detectLastNumber(file, frequencySpec?.start)
+  let number = await detectLastNumber(file, frequencySpec?.start, dateFormat)
 
   let fileName = buildFileName(file, date, number, extension)
   const createdFileNames = [fileName]
@@ -124,8 +125,7 @@ module.exports = async function ({
       createSymlink(fileName)
     }
     if (limit) {
-      createdFileNames.push(fileName)
-      checkFileRemoval(createdFileNames, limit)
+      removeOldFiles({ ...limit, baseFile: file, dateFormat, extension, createdFileNames, newFileName: fileName })
     }
   }
 


### PR DESCRIPTION
This PR addresses #8 by adding `limit.removeOtherLogFiles` to allow for removal of log files not created by the current app run.

In this PR, I've also set that when `dateFormat` option is used, new number counter will restart when the formatted date is different from the previous value.

I've also identified that when using _either or both_ `dateFormat` and `extension` options, the detection of latest numbers is incorrect, leading to issue #75. I'll work on another PR after this one is accepted.