### PR TITLE
feat: implemented the default log file fallback

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -250,6 +250,56 @@ function parseDate (formatStr, frequencySpec, parseStart = false) {
   }
 }
 
+// to implement the default file fallback feature
+function sanitizeFile (file, extension) {
+  if (typeof file === 'function') {
+    file = file()
+  }
+  if (!file) {
+    throw new Error('No file name provided')
+  }
+
+  // defining default file name values
+  const FALLBACK_FILENAME = 'app'
+  const FALLBACK_EXTENSION = 'log'
+
+  const currentFileName = extractFileName(file)
+  if (!currentFileName || currentFileName === '') {
+    file += FALLBACK_FILENAME
+  }
+
+  // only removing the last extension, (to support exact file pattern and multiple ext like app.prod.log)
+  let currentFileExtension = ''
+  if (currentFileName.includes('.')) {
+    const fileParts = file.split('.')
+    currentFileExtension = fileParts.pop()
+    file = fileParts.join('.')
+  }
+
+  if (!extension && !currentFileExtension) {
+    extension = FALLBACK_EXTENSION
+  } else if (!extension && currentFileExtension.length > 1) {
+    extension = currentFileExtension
+  }
+  return { file, extension }
+}
+
+// to validate and reject characters that are not allowed in filenames (cross-platform safe set, based on Windows restrictions)
+function validateFileName (filepath) {
+  if (typeof filepath === 'function') {
+    filepath = filepath()
+  }
+  if (!filepath) {
+    throw new Error('No file name provided')
+  }
+
+  const invalidChars = /[<>:"|?*\0]/g
+  if (invalidChars.test(filepath)) {
+    throw new Error(`File name contains invalid characters: ${filepath}`)
+  }
+  return true
+}
+
 module.exports = {
   buildFileName,
   identifyLogFile,
@@ -265,5 +315,7 @@ module.exports = {
   getFileSize,
   validateLimitOptions,
   parseDate,
-  validateDateFormat
+  validateDateFormat,
+  sanitizeFile,
+  validateFileName
 }

--- a/pino-roll.js
+++ b/pino-roll.js
@@ -12,7 +12,9 @@ const {
   getFileSize,
   validateLimitOptions,
   parseDate,
-  validateDateFormat
+  validateDateFormat,
+  sanitizeFile,
+  validateFileName
 } = require('./lib/utils')
 
 /**
@@ -83,11 +85,15 @@ module.exports = async function ({
 } = {}) {
   validateLimitOptions(limit)
   validateDateFormat(dateFormat)
+  validateFileName(file)
   const frequencySpec = parseFrequency(frequency)
 
   let date = parseDate(dateFormat, frequencySpec, true)
-  let number = await detectLastNumber(file, frequencySpec?.start, extension)
+  const sanitizedFile = sanitizeFile(file)
+  file = sanitizedFile.file
+  extension = sanitizedFile.extension
 
+  let number = await detectLastNumber(file, frequencySpec?.start, extension)
   let fileName = buildFileName(file, date, number, extension)
   const createdFileNames = [fileName]
   let currentSize = await getFileSize(fileName)

--- a/test/date-format-option.test.js
+++ b/test/date-format-option.test.js
@@ -20,7 +20,7 @@ test('rotate file with date format based on frequency', async ({ ok, rejects }) 
   stream.end()
 
   const fileName = `${file}.${format(new Date(), 'yyyy-MM-dd-hh')}`
-  const content = await readFile(`${fileName}.1`, 'utf8')
+  const content = await readFile(`${fileName}.1.log`, 'utf8')
   ok(content.includes('#1'), 'first file contains first log')
   ok(content.includes('#2'), 'first file contains second log')
   rejects(stat(`${fileName}.2`), 'no other files created')
@@ -38,18 +38,18 @@ test('rotate file based on custom time and date format', async ({ ok, notOk, rej
   stream.write('logged message #4\n')
   await sleep(110)
   stream.end()
-  await stat(`${fileName}.1`)
-  let content = await readFile(`${fileName}.1`, 'utf8')
+  await stat(`${fileName}.1.log`)
+  let content = await readFile(`${fileName}.1.log`, 'utf8')
   ok(content.includes('#1'), 'first file contains first log')
   ok(content.includes('#2'), 'first file contains second log')
   notOk(content.includes('#3'), 'first file does not contains third log')
-  await stat(`${fileName}.2`)
-  content = await readFile(`${fileName}.2`, 'utf8')
+  await stat(`${fileName}.2.log`)
+  content = await readFile(`${fileName}.2.log`, 'utf8')
   ok(content.includes('#3'), 'first file contains third log')
   ok(content.includes('#4'), 'first file contains fourth log')
   notOk(content.includes('#2'), 'first file does not contains second log')
-  await stat(`${fileName}.3`)
-  rejects(stat(`${fileName}.4`), 'no other files created')
+  await stat(`${fileName}.3.log`)
+  rejects(stat(`${fileName}.4.log`), 'no other files created')
 })
 
 test('rotate file based on size and date format', async ({ ok, rejects }) => {
@@ -62,14 +62,14 @@ test('rotate file based on size and date format', async ({ ok, rejects }) => {
   await once(stream, 'ready')
   stream.write('logged message #3\n')
   stream.end()
-  let stats = await stat(`${fileWithDate}.1`)
+  let stats = await stat(`${fileWithDate}.1.log`)
   ok(
     size <= stats.size && stats.size <= size * 2,
     `first file size: ${size} <= ${stats.size} <= ${size * 2}`
   )
-  stats = await stat(`${fileWithDate}.2`)
+  stats = await stat(`${fileWithDate}.2.log`)
   ok(stats.size <= size, `second file size: ${stats.size} <= ${size}`)
-  rejects(stat(`${fileWithDate}.3`), 'no other files created')
+  rejects(stat(`${fileWithDate}.3.log`), 'no other files created')
 })
 
 test('rotate file based on size and date format with custom frequency', async ({ ok, rejects }) => {
@@ -85,17 +85,17 @@ test('rotate file based on size and date format with custom frequency', async ({
   stream.write('logged message #4\n')
   stream.end()
 
-  let stats = await stat(`${fileWithDate}.1`)
+  let stats = await stat(`${fileWithDate}.1.log`)
   ok(
     size <= stats.size && stats.size <= size * 2,
     `first file size: ${size} <= ${stats.size} <= ${size * 2}`
   )
-  stats = await stat(`${fileWithDate}.2`)
+  stats = await stat(`${fileWithDate}.2.log`)
   ok(stats.size <= size, `second file size: ${stats.size} <= ${size}`)
-  stats = await stat(`${fileWithDate}.3`)
-  const content = await readFile(`${fileWithDate}.3`, 'utf8')
+  stats = await stat(`${fileWithDate}.3.log`)
+  const content = await readFile(`${fileWithDate}.3.log`, 'utf8')
   ok(content.includes('#4'), 'Rotated file should have the log')
-  rejects(stat(`${file}.4`), 'no other files created')
+  rejects(stat(`${file}.4.log`), 'no other files created')
 })
 
 test('rotate file based on size and date format without frequency', async ({ ok, rejects }) => {
@@ -107,14 +107,14 @@ test('rotate file based on size and date format without frequency', async ({ ok,
   await once(stream, 'ready')
   stream.write('logged message #3\n')
   stream.end()
-  let stats = await stat(`${file}.1`)
+  let stats = await stat(`${file}.1.log`)
   ok(
     size <= stats.size && stats.size <= size * 2,
     `first file size: ${size} <= ${stats.size} <= ${size * 2}`
   )
-  stats = await stat(`${file}.2`)
+  stats = await stat(`${file}.2.log`)
   ok(stats.size <= size, `second file size: ${stats.size} <= ${size}`)
-  rejects(stat(`${file}.3`), 'no other files created')
+  rejects(stat(`${file}.3.log`), 'no other files created')
 })
 
 test('throw on invalid date format', async ({ rejects }) => {

--- a/test/pino-roll.test.js
+++ b/test/pino-roll.test.js
@@ -24,18 +24,18 @@ test('rotate file based on time', async ({ ok, notOk, rejects }) => {
   stream.write('logged message #4\n')
   await sleep(110)
   stream.end()
-  await stat(`${file}.1`)
-  let content = await readFile(`${file}.1`, 'utf8')
+  await stat(`${file}.1.log`)
+  let content = await readFile(`${file}.1.log`, 'utf8')
   ok(content.includes('#1'), 'first file contains first log')
   ok(content.includes('#2'), 'first file contains second log')
   notOk(content.includes('#3'), 'first file does not contains third log')
-  await stat(`${file}.2`)
-  content = await readFile(`${file}.2`, 'utf8')
+  await stat(`${file}.2.log`)
+  content = await readFile(`${file}.2.log`, 'utf8')
   ok(content.includes('#3'), 'second file contains third log')
   ok(content.includes('#4'), 'second file contains fourth log')
   notOk(content.includes('#2'), 'second file does not contains second log')
-  await stat(`${file}.3`)
-  rejects(stat(`${file}.4`), 'no other files created')
+  await stat(`${file}.3.log`)
+  rejects(stat(`${file}.4.log`), 'no other files created')
 })
 
 test('rotate file based on time and parse filename func', async ({ ok, notOk, rejects }) => {
@@ -62,28 +62,28 @@ test('rotate file based on size', async ({ ok, rejects }) => {
   stream.write('logged message #2\n')
   await once(stream, 'ready')
   stream.write('logged message #3\n')
-  let stats = await stat(`${file}.1`)
+  let stats = await stat(`${file}.1.log`)
   ok(
     size <= stats.size && stats.size <= size * 2,
     `first file size: ${size} <= ${stats.size} <= ${size * 2}`
   )
-  stats = await stat(`${file}.2`)
+  stats = await stat(`${file}.2.log`)
   ok(stats.size <= size, `second file size: ${stats.size} <= ${size}`)
-  rejects(stat(`${file}.3`), 'no other files created')
+  rejects(stat(`${file}.3.log`), 'no other files created')
 })
 
 test('resume writing in last file', async ({ equal, rejects }) => {
   const file = join(logFolder, 'log')
   const previousContent = '--previous content--\n'
   const newContent = 'logged message #1\n'
-  await writeFile(`${file}.6`, previousContent)
+  await writeFile(`${file}.6.log`, previousContent)
   const size = 20
   const stream = await buildStream({ size: `${size}o`, file })
   stream.write(newContent)
   await sleep(10)
 
   equal(
-    await readFile(`${file}.6`, 'utf8'),
+    await readFile(`${file}.6.log`, 'utf8'),
     `${previousContent}${newContent}`,
     'old and new content were written'
   )
@@ -102,15 +102,15 @@ test('remove files based on count', async ({ ok, rejects }) => {
     await sleep(20)
   }
   stream.end()
-  await stat(`${file}.2`)
-  let content = await readFile(`${file}.2`, 'utf8')
+  await stat(`${file}.2.log`)
+  let content = await readFile(`${file}.2.log`, 'utf8')
   ok(content.includes('#3'), 'second file contains thrid log')
   ok(content.includes('#4'), 'second file contains fourth log')
-  await stat(`${file}.3`)
-  content = await readFile(`${file}.3`, 'utf8')
+  await stat(`${file}.3.log`)
+  content = await readFile(`${file}.3.log`, 'utf8')
   ok(content.includes('#5'), 'third file contains fifth log')
-  await rejects(stat(`${file}.1`), 'first file was deleted')
-  await rejects(stat(`${file}.4`), 'no other files created')
+  await rejects(stat(`${file}.1.log`), 'first file was deleted')
+  await rejects(stat(`${file}.4.log`), 'no other files created')
 })
 
 test('removeOtherOldFiles()', async ({ ok, notOk }) => {
@@ -150,8 +150,8 @@ test('do not remove pre-existing file when removing files based on count', async
   rejects
 }) => {
   const file = join(logFolder, 'log')
-  await writeFile(`${file}.1`, 'oldest content')
-  await writeFile(`${file}.2`, 'old content')
+  await writeFile(`${file}.1.log`, 'oldest content')
+  await writeFile(`${file}.2.log`, 'old content')
   const stream = await buildStream({
     size: '20b',
     file,
@@ -162,21 +162,21 @@ test('do not remove pre-existing file when removing files based on count', async
     await sleep(20)
   }
   stream.end()
-  await stat(`${file}.1`)
-  let content = await readFile(`${file}.1`, 'utf8')
+  await stat(`${file}.1.log`)
+  let content = await readFile(`${file}.1.log`, 'utf8')
   equal(content, 'oldest content', 'oldest file was not touched')
-  await stat(`${file}.3`)
-  content = await readFile(`${file}.3`, 'utf8')
+  await stat(`${file}.3.log`)
+  content = await readFile(`${file}.3.log`, 'utf8')
   ok(content.includes('#3'), 'second file contains third log')
-  await stat(`${file}.4`)
-  content = await readFile(`${file}.4`, 'utf8')
+  await stat(`${file}.4.log`)
+  content = await readFile(`${file}.4.log`, 'utf8')
   ok(content.includes('#4'), 'third file contains fourth log')
   ok(content.includes('#5'), 'third file contains fifth log')
-  await stat(`${file}.5`)
-  content = await readFile(`${file}.5`, 'utf8')
+  await stat(`${file}.5.log`)
+  content = await readFile(`${file}.5.log`, 'utf8')
   ok(content.includes('#6'), 'fourth file contains sixth log')
-  await rejects(stat(`${file}.2`), 'resumed file was deleted')
-  await rejects(stat(`${file}.6`), 'no other files created')
+  await rejects(stat(`${file}.2.log`), 'resumed file was deleted')
+  await rejects(stat(`${file}.6.log`), 'no other files created')
 })
 
 test('remove pre-existing log files when removing files based on count when limit.removeOtherLogFiles', async ({
@@ -206,14 +206,14 @@ test('remove pre-existing log files when removing files based on count when limi
     if (i < 3) await sleep(550)
   }
   stream.end()
-  rejects(stat(`${prevFile}.1`), 'oldest file was deleted')
+  rejects(stat(`${prevFile}.1.log`), 'oldest file was deleted')
   let content = await readFile(notLogFileName, 'utf8')
   ok(content.includes('not a log file'), 'non-log file is untouched')
-  content = await readFile(`${file1}.2`, 'utf8')
+  content = await readFile(`${file1}.2.log`, 'utf8')
   ok(content.includes('#2'), 'TS1 - 2 file contains second log')
-  content = await readFile(`${file2}.1`, 'utf8')
+  content = await readFile(`${file2}.1.log`, 'utf8')
   ok(content.includes('#3'), 'TS2 - 1 file contains third log')
-  rejects(stat(`${file2}.2`), 'no other files created')
+  rejects(stat(`${file2}.2.log`), 'no other files created')
 })
 
 test('throw on missing file parameter', async ({ rejects }) => {
@@ -228,7 +228,7 @@ test('throw on unexisting folder without mkdir', async ({ rejects }) => {
   const file = join('unknown', 'folder', 'file')
   rejects(
     buildStream({ file }),
-    { message: `ENOENT: no such file or directory, open '${file}.1'` },
+    { message: `ENOENT: no such file or directory, open '${file}.1.log'` },
     'throws on unexisting folder'
   )
 })
@@ -292,7 +292,7 @@ test('creates symlink if prop is set', async ({ equal, resolves }) => {
   await sleep(200)
   await resolves(lstat(linkPath), 'symlink was created')
   const linkTarget = await readlink(linkPath)
-  equal(linkTarget, 'log.1', 'symlink points to the correct file')
+  equal(linkTarget, 'log.1.log', 'symlink points to the correct file')
   const content = await readFile(linkPath, 'utf8')
   equal(content, 'test content\n', 'symlink contains correct content')
 })
@@ -311,7 +311,7 @@ test('symlink rotates on roll', async ({ equal, ok, resolves }) => {
   await sleep(200)
   await resolves(lstat(linkPath), 'symlink was created')
   const linkTarget = await readlink(linkPath)
-  equal(linkTarget, 'log.2', 'symlink points to the correct file')
+  equal(linkTarget, 'log.2.log', 'symlink points to the correct file')
   const content = await readFile(linkPath, 'utf8')
   ok(content.includes('#4'), 'symlink contains fourth log')
 })


### PR DESCRIPTION
## Description

This PR introduces a `sanitizeFile` utility to **normalize** file paths and extensions for `Pino-roll`, ensuring predictable and consistent filenames during log rotation.

### Background

While using pino-roll in production, I noticed inconsistencies in rotated filenames when the provided path ends with a `/` or lacks an explicit extension. This sometimes resulted in hidden files (e.g., `.2025-08-11.1` or `.1`), which made automation or grep-based searches unreliable.

This problem was also raised earlier by another user in issue #118, and this PR builds on that discussion by introducing a default log file fallback to ensure consistent and predictable file naming.

Special thanks to @rotu for first highlighting this issue in #118.

### Current Behavior

```
/** Actual Behavior
 * When explicit extension (.log) and date are provided
 * ./logx/prod.log -> ./logx/prod.log.2025-08-11.1.log
 * ./logx/prod -> ./logx/prod.2025-08-11.1.log
 * ./logx/ -> ./logx/.2025-08-11.1.log
 * 
 * When no explicit extension is given, but the date provided
 * ./logy/prod.log -> ./logy/prod.log.2025-08-11.1
 * ./logy/prod -> ./logy/prod.2025-08-11.1
 * ./logy/ -> ./logy/.2025-08-11.1
 * 
 * When explicit extension and date are not provided
 * ./logz/prod.log -> ./logz/prod.log.1
 * ./logz/prod -> ./logz/prod.1
 * ./logz/ -> ./logz/.1
 */
```
> We can clearly see inconsistencies in the current behavior.

### Updated Behavior

With this change, rotated filenames will always follow a consistent and predictable pattern using the Extension Last Format convention:

```
filename.date.count.extension
(e.g., prod.2025-08-18.1.log)
```
For Example:

```
/** Updated Behavior
 * When explicit extension (.log) and date are provided
 * ./logx/prod.log -> ./logx/prod.2025-08-11.1.log
 * ./logx/prod -> ./logx/prod.2025-08-11.1.log
 * ./logx/ -> ./logx/app.2025-08-11.1.log
 * 
 * When no explicit extension is given, but the date provided
 * ./logy/prod.log -> ./logy/prod.2025-08-11.1.log
 * ./logy/prod -> ./logy/prod.2025-08-11.1.log
 * ./logy/ -> ./logy/app.2025-08-11.1.log
 * 
 * When explicit extension and date are not provided
 * ./logz/prod.log -> ./logz/prod.1.log
 * ./logz/prod -> ./logz/prod.1.log
 * ./logz/ -> ./logz/app.1.log
 */
```

### Key Improvements

- **Predictable, grep-friendly filenames** → Developers can reliably search logs without worrying about hidden files or multiple formats.
- **Consistency with standard rotation formats** → Aligns with `filename.date.count.extension` patterns commonly used in Node.js logging tools (e.g., pino, winston with rotation plugins), ensuring predictable and easily sortable log filenames.
- **No hidden files from trailing slashes** → Automatically adds a default basename (`app` or `app.log`) to paths ending with `/`.
- **Cross-platform filename safety** → Rejects invalid characters (based on `Windows restrictions`) to ensure generated filenames are valid everywhere.

### Implementation

- Introduced `sanitizeFile(file, extension)` utility:
  - Provides fallback basename (`app`) and extension (`log`) when missing. 
  - Preserves multiple extensions (e.g., `app.prod.log`).
  - Handles trailing slashes safely.
- Added `validateFileName(filepath)` utility:
  - Rejects invalid characters such as `< > : " | ? *` for cross-platform safety.
- Added comprehensive tests covering:
  - Input validation
  - Extension handling
  - Multiple extensions
  - Trailing slash scenarios
  - Default fallbacks

### Breaking Changes

- Existing projects relying on paths ending with `/` and expecting `.1`**-style** hidden files may observe different filenames.
- Projects that relied on the `filename.extension.date.count` format will need to adjust to the new `filename.date.count.extension` format.
- These changes alter existing file naming behavior and therefore justify a ***major version bump***.

### Testing

- Added tests in `test/lib/utils.test.js`.
- Updated rotation tests in `test/pino-roll.test.js` and `test/date-format-option.test.js` to cover new behavior.

### Summary

**This PR ensures filenames are consistent, predictable, and safe across platforms, while preparing `Pino-roll` for broader adoption in production environments.**

---

CC @mcollina, would appreciate your review, since this introduces a breaking change.  
Happy to adjust if you’d like any changes.