### PR TITLE
docs: clarify file function limitation in pino.transport

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,50 @@ const transport = pino.transport({
 })
 ```
 
-If you need a `file` function, build `pino-roll` directly in-process (without `pino.transport()`).
+If you do not need `pino.transport()`, you can also call `pino-roll` directly in-process and pass `file` as a function.
+
+If you need to keep using `pino.transport()` and still compute the final path dynamically, create a custom transport module that calls `pino-roll` in the worker thread.
+
+```js
+// my-pino-roll-transport.js
+'use strict'
+
+const { join } = require('path')
+const buildPinoRoll = require('pino-roll')
+
+module.exports = async function myPinoRollTransport ({
+  folder,
+  prefix = 'app',
+  ...rollOptions
+} = {}) {
+  const dateStamp = new Date().toISOString().slice(0, 10)
+  const file = join(folder, `${prefix}-${dateStamp}`)
+  return buildPinoRoll({ ...rollOptions, file })
+}
+```
+
+```js
+// app.js
+const { join } = require('path')
+const pino = require('pino')
+
+const transport = pino.transport({
+  target: join(__dirname, 'my-pino-roll-transport.js'),
+  options: {
+    folder: join(__dirname, 'logs'),
+    prefix: 'server',
+    frequency: 'daily',
+    mkdir: true
+  }
+})
+
+const logger = pino(transport)
+logger.info('hello from custom transport')
+```
+
+A runnable version of this pattern is available in:
+- `examples/custom-transport/pino-roll-dynamic-transport.js`
+- `examples/custom-transport/app.js`
 
 ## API
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,26 @@ const logger = pino(transport)
 
 (Also works in CommonJS)
 
+### Important note about `file` functions
+
+`pino.transport()` sends `options` to a worker thread using the structured clone algorithm.
+Functions are not cloneable, so `file: () => '...'` will throw `DataCloneError` when used this way.
+
+If you need dynamic filenames with `pino.transport()`, use `dateFormat` + `frequency`.
+
+```js
+const transport = pino.transport({
+  target: 'pino-roll',
+  options: {
+    file: 'log-files/file',
+    frequency: 'daily',
+    dateFormat: 'yyyy.MM.dd',
+    mkdir: true
+  }
+})
+```
+
+If you need a `file` function, build `pino-roll` directly in-process (without `pino.transport()`).
 
 ## API
 
@@ -43,7 +63,7 @@ You can specify any of [Sonic-Boom options](https://github.com/pinojs/sonic-boom
   - A rotation number will be appended to this filename.
   - When the parent folder already contains numbered files, numbering will continue based on the highest number.
   - If this path does not exist, the logger will throw an error unless you set `mkdir` to `true`.
-  - `file` may also be a function that returns a string.
+  - `file` may be a function only when you build `pino-roll` directly in-process. It is not supported in `pino.transport()` options.
 
   - To ensure consistency, rotated filenames now always follow the **Extension Last Format** convention:
     ```

--- a/examples/custom-transport/app.js
+++ b/examples/custom-transport/app.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const { join } = require('path')
+const pino = require('pino')
+
+const transport = pino.transport({
+  target: join(__dirname, 'pino-roll-dynamic-transport.js'),
+  options: {
+    folder: join(__dirname, 'logs'),
+    baseName: 'server',
+    frequency: 'daily',
+    dateFormat: 'yyyy-MM-dd'
+  }
+})
+
+const logger = pino(transport)
+
+logger.info('hello from custom pino-roll transport')
+
+transport.on('ready', () => {
+  logger.info('transport ready')
+})

--- a/examples/custom-transport/pino-roll-dynamic-transport.js
+++ b/examples/custom-transport/pino-roll-dynamic-transport.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const { join } = require('path')
+const buildPinoRoll = require('../..')
+
+module.exports = async function pinoRollDynamicTransport ({
+  folder = 'logs',
+  baseName = 'app',
+  mkdir = true,
+  ...rollOptions
+} = {}) {
+  const dateStamp = new Date().toISOString().slice(0, 10)
+  const file = join(folder, `${baseName}-${dateStamp}`)
+
+  return buildPinoRoll({ ...rollOptions, file, mkdir })
+}

--- a/fixtures/custom-pino-roll-transport.js
+++ b/fixtures/custom-pino-roll-transport.js
@@ -1,0 +1,12 @@
+'use strict'
+
+const { join } = require('path')
+const build = require('..')
+
+module.exports = async function customPinoRollTransport ({ folder, prefix = 'app', ...options } = {}) {
+  const now = new Date()
+  const dateStamp = now.toISOString().slice(0, 10)
+  const file = join(folder, `${prefix}-${dateStamp}`)
+
+  return build({ ...options, file })
+}

--- a/pino-roll.js
+++ b/pino-roll.js
@@ -32,6 +32,7 @@ const {
  * Number will be appended to this file name.
  * When the parent folder already contains numbered files, numbering will continue based on the highest number.
  * If this path does not exist, the logger with throw an error unless you set `mkdir` to `true`.
+ * Note: when used through `pino.transport()`, `file` must be a string because worker options are structured-cloned.
  *
  * @property {string|number} size? - When specified, the maximum size of a given log file.
  * Can be combined with frequency.

--- a/test/custom-transport.test.js
+++ b/test/custom-transport.test.js
@@ -1,0 +1,58 @@
+'use strict'
+
+const { once } = require('events')
+const { readdir, readFile } = require('fs/promises')
+const { join } = require('path')
+const { it, beforeEach } = require('node:test')
+const assert = require('node:assert')
+const pino = require('pino')
+
+const { createTempTestDir, waitForCondition } = require('./utils')
+
+let logFolder
+
+beforeEach(() => {
+  logFolder = createTempTestDir()
+})
+
+it('supports dynamic filenames via a custom transport wrapper', async () => {
+  const transport = pino.transport({
+    target: join(__dirname, '..', 'fixtures', 'custom-pino-roll-transport.js'),
+    options: {
+      folder: logFolder,
+      prefix: 'server',
+      mkdir: true
+    }
+  })
+
+  try {
+    await once(transport, 'ready')
+    const logger = pino(transport)
+    logger.info('logged from wrapper transport')
+
+    let fileName
+
+    await waitForCondition(
+      async () => {
+        const files = await readdir(logFolder)
+        fileName = files.find(file => file.startsWith('server-') && file.endsWith('.1.log'))
+        if (!fileName) return false
+
+        const content = await readFile(join(logFolder, fileName), 'utf8')
+        return content.includes('logged from wrapper transport')
+      },
+      {
+        timeout: 5000,
+        interval: 50,
+        description: 'custom transport log file to contain message'
+      }
+    )
+
+    assert.ok(fileName, 'custom transport created a dated log file')
+  } finally {
+    if (!transport.closed) {
+      transport.end()
+      await once(transport, 'close')
+    }
+  }
+})

--- a/test/custom-transport.test.js
+++ b/test/custom-transport.test.js
@@ -52,7 +52,14 @@ it('supports dynamic filenames via a custom transport wrapper', async () => {
   } finally {
     if (!transport.closed) {
       transport.end()
-      await once(transport, 'close')
+      await waitForCondition(
+        async () => transport.closed,
+        {
+          timeout: 3000,
+          interval: 25,
+          description: 'custom transport to close'
+        }
+      )
     }
   }
 })


### PR DESCRIPTION
## Summary
- document why `file: () => string` fails when `pino-roll` is used through `pino.transport()`
- add a prominent README note about worker-thread structured clone limitations
- add docs showing a custom wrapper transport that computes dynamic file paths inside the worker thread
- add runnable examples:
  - `examples/custom-transport/pino-roll-dynamic-transport.js`
  - `examples/custom-transport/app.js`
- add an integration test proving the custom wrapper approach works:
  - `test/custom-transport.test.js`

## Verification
- npm test

Closes #143.
Closes #99.
